### PR TITLE
Feature/#20 포켓몬파티라인업유지

### DIFF
--- a/src/PokemonContextProvider.jsx
+++ b/src/PokemonContextProvider.jsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useState } from "react";
+import { createContext, useState } from "react";
 
 const PokemonContext = createContext();
 

--- a/src/PokemonContextProvider.jsx
+++ b/src/PokemonContextProvider.jsx
@@ -1,4 +1,4 @@
-import { createContext, useState } from "react";
+import { createContext, useEffect, useState } from "react";
 
 const PokemonContext = createContext();
 

--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -7,18 +7,13 @@ import Details from "./pages/Details";
 const Router = () => {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Home />}></Route>
-        <Route
-          path="dex"
-          element={
-            <PokemonContextProvider>
-              <Dex />
-            </PokemonContextProvider>
-          }
-        ></Route>
-        <Route path="details/:id" element={<Details />}></Route>
-      </Routes>
+      <PokemonContextProvider>
+        <Routes>
+          <Route path="/" element={<Home />}></Route>
+          <Route path="dex" element={<Dex />}></Route>
+          <Route path="details/:id" element={<Details />}></Route>
+        </Routes>
+      </PokemonContextProvider>
     </BrowserRouter>
   );
 };

--- a/src/pages/Details.jsx
+++ b/src/pages/Details.jsx
@@ -7,7 +7,7 @@ const Details = () => {
   const param = useParams();
   const pokemon = setPokemon(param.id);
 
-  console.log(pokemon);
+  console.log("Details");
 
   const backDex = () => {
     navigate("/dex");

--- a/src/pages/Details.jsx
+++ b/src/pages/Details.jsx
@@ -1,13 +1,30 @@
 import { useNavigate, useParams } from "react-router-dom";
 import MOCK_DATA from "../constants/MOCK_DATA";
 import styled from "styled-components";
+import { useContext } from "react";
+import { PokemonContext } from "../PokemonContextProvider";
 
 const Details = () => {
   const navigate = useNavigate();
   const param = useParams();
-  const pokemon = setPokemon(param.id);
+  const { Lineup, addPokemon, removePokemon } = useContext(PokemonContext);
 
-  console.log("Details");
+  const pokemon = setPokemon(param.id);
+  let action = Lineup.some((poke) => poke.id === pokemon.id) ? "REMOVE" : "ADD";
+
+  const clickAction = (e) => {
+    e.stopPropagation();
+    switch (action) {
+      case "ADD":
+        addPokemon(pokemon);
+        return;
+      case "REMOVE":
+        removePokemon(pokemon);
+        return;
+      default:
+        return;
+    }
+  };
 
   const backDex = () => {
     navigate("/dex");
@@ -24,12 +41,18 @@ const Details = () => {
         {pokemon.description}
       </Info>
       <button onClick={backDex}>뒤로 가기</button>
+      <ActionBtn onClick={clickAction}>{BtnName[action]}</ActionBtn>
     </DetailsLayout>
   );
 };
 
 const setPokemon = (id) => {
   return MOCK_DATA.find((pokemon) => pokemon.id === Number(id));
+};
+
+const BtnName = {
+  ADD: "추가하기",
+  REMOVE: "삭제하기",
 };
 
 const DetailsLayout = styled.div`
@@ -54,6 +77,22 @@ const Info = styled.div`
 
   line-height: 180%;
   /* background-color: green; */
+`;
+
+const ActionBtn = styled.button`
+  width: 80px;
+  height: 30px;
+
+  border: none;
+  border-radius: 10px;
+  margin: 5px 0 0 0;
+  background-color: #ee3f35;
+
+  &:hover {
+    background-color: #3db128;
+    color: white;
+    transition: 0.3s;
+  }
 `;
 
 export default Details;


### PR DESCRIPTION
#20
- Provider 범위 변경을 통한 Lineup 상태 공유
- Details 페이지의 추가, 삭제 기능 삽입
   - 파티에 존재 여부에 따른 케이스 분리